### PR TITLE
PBRP: Enable qti input haptics vibrators support

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -10,6 +10,11 @@ LOCAL_SRC_FILES := \
     graphics_utils.cpp \
     events.cpp
 
+ifeq ($(PB_SUPPORT_INPUT_HAPTICS),true)
+    LOCAL_SHARED_LIBRARIES += android.hardware.vibrator@1.2 libhidlbase
+    LOCAL_CFLAGS += -DUSE_QTI_HAPTICS
+endif
+
 ifneq ($(TW_BOARD_CUSTOM_GRAPHICS),)
     $(warning ****************************************************************************)
     $(warning * TW_BOARD_CUSTOM_GRAPHICS support has been deprecated in TWRP.            *)

--- a/minuitwrp/events.cpp
+++ b/minuitwrp/events.cpp
@@ -28,6 +28,10 @@
 #include <string.h>
 #include <fstream>
 
+#ifdef USE_QTI_HAPTICS
+#include <android/hardware/vibrator/1.2/IVibrator.h>
+#endif
+
 #include "../common.h"
 
 #include "minui.h"
@@ -130,12 +134,18 @@ int vibrate(int timeout_ms)
     char tout[6];
     sprintf(tout, "%i", timeout_ms);
 
+#ifndef USE_QTI_HAPTICS
     if (std::ifstream(LEDS_HAPTICS_ACTIVATE_FILE).good()) {
         write_to_file(LEDS_HAPTICS_DURATION_FILE, std::to_string(timeout_ms));
         write_to_file(LEDS_HAPTICS_ACTIVATE_FILE, "1");
     } else
         write_to_file(VIBRATOR_TIMEOUT_FILE, std::to_string(timeout_ms));
-
+#else
+    android::sp<android::hardware::vibrator::V1_2::IVibrator> vib = android::hardware::vibrator::V1_2::IVibrator::getService();
+    if (vib != nullptr) {
+        vib->on((uint32_t)timeout_ms);
+    }
+#endif
     return 0;
 }
 #endif

--- a/prebuilt/Android.mk
+++ b/prebuilt/Android.mk
@@ -228,6 +228,10 @@ ifeq ($(TW_INCLUDE_CRYPTO), true)
             RELINK_SOURCE_FILES += $(TARGET_OUT_EXECUTABLES)/keystore_cli
             RELINK_SOURCE_FILES += $(TARGET_OUT_EXECUTABLES)/servicemanager
             RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/android.system.wifi.keystore@1.0.so
+            RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/android.hardware.vibrator@1.0.so
+            RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/android.hardware.vibrator@1.1.so
+            RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/android.hardware.vibrator@1.2.so
+
             ifneq ($(wildcard system/keymaster/keymaster_stl.cpp),)
                 RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/libkeymaster_portable.so
                 RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/libkeymaster_staging.so


### PR DESCRIPTION
 * these type of vibrators are present in newer devices based on board sm8150 & above. Like Oneplus 7 series, Redmi K20 Pro, etc.

Change-Id: I0fe6612def149e70808ca41829b6f7ba0b23cd62
Signed-off-by: Mohd Faraz <androiabledroid@gmail.com>