### PR TITLE
Unmount system and vendor partitions before flashing

### DIFF
--- a/data.cpp
+++ b/data.cpp
@@ -873,6 +873,7 @@ void DataManager::SetDefaultValues()
 #endif
         mPersist.SetValue(TRB_EN, "0");
         mPersist.SetValue(STD, "0");
+	mPersist.SetValue(TW_UNMOUNT_SYSTEM, "1");
 #ifdef TW_NO_SCREEN_TIMEOUT
 	mConst.SetValue("tw_screen_timeout_secs", "0");
 	mConst.SetValue("tw_no_screen_timeout", "1");

--- a/gui/theme/common/lang_en/languages/en.xml
+++ b/gui/theme/common/lang_en/languages/en.xml
@@ -928,6 +928,8 @@
 		<string name="sel_br_val">Flashlight Brightness Value: %pb_bright_value%%</string>
 		<string name="unmount_sys_install">Unmount System before installing a ZIP</string>
 		<string name="unmount_system">Unmounting System...</string>
+		<string name="unmount_vendor">Unmounting Vendor...</string>
 		<string name="unmount_system_err">Failed unmounting System</string>
+		<string name="unmount_vendor_err">Failed unmounting Vendor</string>
 	</resources>
 </language>

--- a/gui/theme/common/lang_en/languages/en.xml
+++ b/gui/theme/common/lang_en/languages/en.xml
@@ -926,5 +926,8 @@
 		<string name="pb_wipe_fbe_cache">FBE Cache</string>
 		<string name="fbe_done">-- FBE Cache Wipe Complete!</string>
 		<string name="sel_br_val">Flashlight Brightness Value: %pb_bright_value%%</string>
+		<string name="unmount_sys_install">Unmount System before installing a ZIP</string>
+		<string name="unmount_system">Unmounting System...</string>
+		<string name="unmount_system_err">Failed unmounting System</string>
 	</resources>
 </language>

--- a/gui/theme/common/portrait.xml
+++ b/gui/theme/common/portrait.xml
@@ -3761,6 +3761,9 @@
 				<listitem name="{@use_aromafm=Use Aroma File Manager}">
 					<data variable="aromafm"/>
 				</listitem>
+                                <listitem name="{@unmount_sys_install=Unmount System before installing a ZIP}">
+                                        <data variable="tw_unmount_system"/>
+                                </listitem>
 			</listbox>
 
 			<button style="main_button_half_height_new">

--- a/twinstall.cpp
+++ b/twinstall.cpp
@@ -546,7 +546,7 @@ static int Run_Update_Binary(const char *path, ZipWrap *Zip, int* wipe_cache, zi
 }
 
 int TWinstall_zip(const char* path, int* wipe_cache) {
-	int ret_val, zip_verify = 1;
+	int ret_val, zip_verify = 1, unmount_system = 1;
 
 	if (strcmp(path, "error") == 0) {
 		LOGERR("Failed to get adb sideload file: '%s'\n", path);
@@ -577,6 +577,8 @@ int TWinstall_zip(const char* path, int* wipe_cache) {
 		}
 	}
   }
+
+	DataManager::GetValue(TW_UNMOUNT_SYSTEM, unmount_system);
 
 #ifndef TW_OEM_BUILD
 	DataManager::GetValue(TW_SIGNED_ZIP_VERIFY_VAR, zip_verify);
@@ -630,6 +632,16 @@ int TWinstall_zip(const char* path, int* wipe_cache) {
 			sysReleaseMap(&map);
 #endif
 		return INSTALL_CORRUPT;
+	}
+
+	if (unmount_system) {
+		gui_msg("unmount_system=Unmounting System...");
+		if(!PartitionManager.UnMount_By_Path(PartitionManager.Get_Android_Root_Path(), true)) {
+			gui_err("unmount_system_err=Failed unmounting System");
+			return -1;
+		}
+		unlink("/system");
+		mkdir("/system", 0755);
 	}
 
 	time_t start, stop;

--- a/twinstall.cpp
+++ b/twinstall.cpp
@@ -556,13 +556,6 @@ int TWinstall_zip(const char* path, int* wipe_cache) {
 
 
     if (DataManager::GetIntValue(PB_INSTALL_PREBUILT_ZIP) != 1) {
-
-	/* First delink all our symlinks to /system, coz we donno the behaviour of the flashing zip */
-	if (PartitionManager.Is_Mounted_By_Path("/system_root") || TWFunc::Path_Exists("/system/system"))
-	{
-		string UM ="/system";
-		umount(UM.c_str());
-	}
 	gui_msg(Msg("installing_zip=Installing zip file '{1}'")(path));
 	if (strlen(path) < 9 || strncmp(path, "/sideload", 9) != 0) {
 		string digest_str;
@@ -635,13 +628,20 @@ int TWinstall_zip(const char* path, int* wipe_cache) {
 	}
 
 	if (unmount_system) {
+		gui_msg("unmount_vendor=Unmounting Vendor...");
+		if(!PartitionManager.UnMount_By_Path("/vendor", true)) {
+			gui_err("unmount_vendor_err=Failed unmounting Vendor");
+		} else {
+		unlink("/vendor");
+		mkdir("/vendor", 0755);
+		}
 		gui_msg("unmount_system=Unmounting System...");
 		if(!PartitionManager.UnMount_By_Path(PartitionManager.Get_Android_Root_Path(), true)) {
 			gui_err("unmount_system_err=Failed unmounting System");
-			return -1;
-		}
+		} else {
 		unlink("/system");
 		mkdir("/system", 0755);
+		}
 	}
 
 	time_t start, stop;

--- a/variables.h
+++ b/variables.h
@@ -145,6 +145,7 @@
 #define TW_MILITARY_TIME            "tw_military_time"
 #define TW_USE_SHA2                 "tw_use_sha2"
 #define TW_NO_SHA2                  "tw_no_sha2"
+#define TW_UNMOUNT_SYSTEM           "tw_unmount_system"
 #define TW_IS_SUPER                 "tw_is_super"
 
 // PitchBlack Variables


### PR DESCRIPTION
Mounted by default and end up in flashing error unless we unmount them manually before flashing (dynamic partitions).