### PR TITLE
bootable:recovery: Reduce Recovery Size for Some Devices

### DIFF
--- a/gui/Android.mk
+++ b/gui/Android.mk
@@ -233,14 +233,14 @@ ifeq ($(BOARD_RECOVERYIMAGE_PARTITION_SIZE),)
     endif
     REQUIRED_RECOVERY_SIZE := $(BOARD_BOOTIMAGE_PARTITION_SIZE)
 endif
-ifeq ($(shell test $(REQUIRED_RECOVERY_SIZE) -le 21073920; echo $$?),0)
+ifeq ($(shell test $(REQUIRED_RECOVERY_SIZE) -le 25165824; echo $$?),0)
     $(warning Recovery Size is small discarding Special fonts)
 endif
 TWRP_RES_GEN := $(intermediates)/twrp
 $(TWRP_RES_GEN):
 	mkdir -p $(TARGET_RECOVERY_ROOT_OUT)$(TWRES_PATH)
 	cp -fr $(TWRP_RES) $(TARGET_RECOVERY_ROOT_OUT)$(TWRES_PATH)
-	if test $(REQUIRED_RECOVERY_SIZE) -le 21073920; then \
+	if test $(REQUIRED_RECOVERY_SIZE) -le 25165824; then \
 	    rm -rf $(TARGET_RECOVERY_ROOT_OUT)$(TWRES_PATH)/fonts/DroidSansFallback.ttf; \
 	    rm -rf $(TARGET_RECOVERY_ROOT_OUT)$(TWRES_PATH)/fonts/NotoSansCJKjp-Regular.ttf; \
 	    rm -rf $(TARGET_RECOVERY_ROOT_OUT)$(TWRES_PATH)/fonts/RoboNoto-Medium.ttf; \


### PR DESCRIPTION
* Some Devices like Redmi Go (tiare) have very small recovery partition , build often fails , this patch fixes it

Signed-off-by: techyminati <sinha.aryan03@gmail.com>

## We Merge Pull Requests Submitted Here After Reviewed By Core Developers

If you are submitting any patches, Tell us a little about it.
<!--
Fixes:
- 
- 
Improvements:
- 
etc.
-->

Kindly wait for Core Developers to review.

### You can join our community on Telegram

- [Community Group](https://t.me/pbrpcom)
- [Test Build & Build Help Group](https://t.me/pbrp_testers)
