### PR TITLE
events: fix haptics on newer Samsung devices

### DIFF
--- a/minuitwrp/events.cpp
+++ b/minuitwrp/events.cpp
@@ -153,6 +153,13 @@ int vibrate(int timeout_ms)
     if (vib != nullptr) {
         vib->on((uint32_t)timeout_ms, nullptr);
     }
+#elif defined(USE_SAMSUNG_HAPTICS)
+    /* Newer Samsung devices have duration file only
+     0 in VIBRATOR_TIMEOUT_FILE means no vibration
+     Anything else is the vibration running for X milliseconds */
+    if (std::ifstream(VIBRATOR_TIMEOUT_FILE).good()) {
+        write_to_file(VIBRATOR_TIMEOUT_FILE, tout);
+    }
 #else
     android::sp<android::hardware::vibrator::V1_2::IVibrator> vib = android::hardware::vibrator::V1_2::IVibrator::getService();
     if (vib != nullptr) {

--- a/minuitwrp/libminuitwrp_defaults.go
+++ b/minuitwrp/libminuitwrp_defaults.go
@@ -19,6 +19,10 @@ func globalFlags(ctx android.BaseContext) []string {
 		cflags = append(cflags, "-DUSE_QTI_AIDL_HAPTICS")
 	}
 
+	if getMakeVars(ctx, "TW_USE_SAMSUNG_HAPTICS") == "true" {
+                cflags = append(cflags, "-DUSE_SAMSUNG_HAPTICS")
+        }
+
 	if getMakeVars(ctx, "TW_TARGET_USES_QCOM_BSP") == "true" {
 		cflags = append(cflags, "-DMSM_BSP")
 	}


### PR DESCRIPTION
Newer Samsung devices have a single file that enables/disables/sets the timeout for vibration in /sys/class/timed_output/vibrator/enable
The content of the file determines the state of the vibrator, 0 being vibrator being off and any other value being the time in ms that the vibrator is going to run before resetting to 0 again.

Change-Id: I1144e139285494e43b8656229ad6df10d5b48f39
Signed-off-by: soulr344 <soul@totsuka.gq>

## We Merge Pull Requests Submitted Here After Reviewed By Core Developers

If you are submitting any patches, Tell us a little about it.
<!--
Fixes:
- 
- 
Improvements:
- 
etc.
-->

Kindly wait for Core Developers to review.

### You can join our community on Telegram

- [Community Group](https://t.me/pbrpcom)
- [Test Build & Build Help Group](https://t.me/pbrp_testers)
