### PR TITLE
Is_Mounted: fix symlink detection to not break internal storage

### DIFF
--- a/partition.cpp
+++ b/partition.cpp
@@ -1559,7 +1559,8 @@ bool TWPartition::Is_Mounted(void) {
 	if (stat(test_path.c_str(), &st2) != 0)  return false;
 
         // Check to see if a symlink mount point exists and is mounted
-        if (!Symlink_Mount_Point.empty()) {
+        // Only apply this check to the main data partition that's not using data/media
+        if (!Symlink_Mount_Point.empty() && Mount_Point == "/data" && !Has_Data_Media) {
             scan_mounted_volumes();
             const MountedVolume * sml = find_mounted_volume_by_mount_point(Symlink_Mount_Point.c_str());
             if (sml != nullptr) {


### PR DESCRIPTION
Fixed issue after https://github.com/PitchBlackRecoveryProject/android_bootable_recovery/commit/c8f9364170e31cd08a4589b763ab622789ce7c31 Internal Storage is Showing 0, obb only